### PR TITLE
Rename with uppercase SOGo

### DIFF
--- a/sogo/metadata.json
+++ b/sogo/metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "sogo",
+    "name": "SOGo",
     "description": {
         "en": "SOGo is a free and modern scalable groupware server."
     },


### PR DESCRIPTION
with the new feature https://github.com/NethServer/ns8-samba/pull/39 the name of sogo is displayed with lower case, we could expect a better human format : SOGo

```
[root@R1-pve ~]# cat /home/samba3/.config/api-moduled/public/config.json 
{"domain": "ad.rocky9-pve.org", "services": ["sogo"]
```