### PR TITLE
Update url of documentation

### DIFF
--- a/mariadb/metadata.json
+++ b/mariadb/metadata.json
@@ -14,7 +14,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://hub.docker.com/_/mariadb",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/mariadb.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-mariadb"
   },


### PR DESCRIPTION
This pull request updates the `documentation_url` in the `mariadb/metadata.json` file to point to the latest official documentation for MariaDB in the NethServer NS8 project.

* Updated the `documentation_url` in `mariadb/metadata.json` to `https://docs.nethserver.org/projects/ns8/en/latest/mariadb.html` for more accurate and relevant documentation references.

https://github.com/NethServer/dev/issues/7399