### PR TITLE
Update url of documentation

### DIFF
--- a/webserver/metadata.json
+++ b/webserver/metadata.json
@@ -12,7 +12,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://github.com/NethServer/ns8-webserver/blob/main/README.md",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/webserver.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-webserver"
   },


### PR DESCRIPTION
This pull request updates the `documentation_url` in the `webserver/metadata.json` file to point to the official NethServer documentation site instead of the GitHub README file.

* [`webserver/metadata.json`](diffhunk://#diff-efb552d781ebf149efd6fc67e20acc55734a6e6997142243e9cc689ac817f6c0L15-R15): Updated the `documentation_url` to `https://docs.nethserver.org/projects/ns8/en/latest/webserver.html` for better alignment with the official documentation.
https://github.com/NethServer/dev/issues/7399