### PR TITLE
Update url of documentation

### DIFF
--- a/dependencytrack/metadata.json
+++ b/dependencytrack/metadata.json
@@ -11,7 +11,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://docs.dependencytrack.org/",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/dependencytrack.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-dependencytrack"
   },


### PR DESCRIPTION
This pull request updates the documentation URL in the `dependencytrack/metadata.json` file to point to the latest NethServer DependencyTrack documentation.

* [`dependencytrack/metadata.json`](diffhunk://#diff-47345b4a5de29edd46a885154d55732e7b2dd0c794950ef4acb37af4d4e45eaaL14-R14): Updated the `documentation_url` to `https://docs.nethserver.org/projects/ns8/en/latest/dependencytrack.html` to reflect the correct and updated documentation location.

https://github.com/NethServer/dev/issues/7399