### PR TITLE
Update url of documentation

### DIFF
--- a/node_exporter/metadata.json
+++ b/node_exporter/metadata.json
@@ -12,7 +12,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://github.com/prometheus/node_exporter",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/metrics.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-node_exporter"
   },


### PR DESCRIPTION
This pull request updates the documentation URL in the metadata file for the `node_exporter` component to point to a more relevant and specific documentation page.

* [`node_exporter/metadata.json`](diffhunk://#diff-3d9cab24373e1548fecc77a23ef73de25d9800cd06811dc794cff38bdde8e18eL15-R15): Changed the `documentation_url` from the Prometheus Node Exporter GitHub page to the NethServer NS8 metrics documentation page.

https://github.com/NethServer/dev/issues/7399